### PR TITLE
startup.vbs: fix the drive letter lookup

### DIFF
--- a/startup.vbs
+++ b/startup.vbs
@@ -13,7 +13,7 @@ For Each objItem in colItems
     Exit For
 Next
  
-If NOT Len(driveLetter) Then
+If IsEmpty(driveLetter) Then
     driveLetter = "C:"
 End If
  


### PR DESCRIPTION
The startup.vbs script does not find the correct drive with the
CONTEXT CD-ROM, and thus contextualization is not done at all.
The problem is the incorrect test whether the lookup succeeded,
and substituting "C:" in case it failed.

The issue with the suggested fix is discussed here:
https://forum.opennebula.org/t/windows-contextualization-problem/579/4