### PR TITLE
README.md: Point back to the ONe documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This addon produces a Windows Contextualization script to use in Windows Guest VMs running in an OpenNebula Cloud.
 
+The documentation on Windows Contextualization can be found in
+the [OpenNebula User's Guide](http://docs.opennebula.org/4.14/user/virtual_machine_setup/windows_context.html).
+
 ## Authors
 
 * Leader: Jaime Melis jmelis@opennebula.org


### PR DESCRIPTION
The Github project page should also provide pointer to the
documentation on how to use Windows Contextualization. Since
the documentation is not contained in the project itself,
add link to the OpenNebula documentation.