### PR TITLE
Wait for NIC and Search for built-in Administrator account fixes

### DIFF
--- a/context.ps1
+++ b/context.ps1
@@ -107,8 +107,11 @@ function configureNetwork($context) {
         }
 
         # Run the configuration
-        $nic = Get-WMIObject Win32_NetworkAdapterConfiguration | `
-                where {$_.IPEnabled -eq "TRUE" -and $_.MACAddress -eq $mac}
+        while(!$nic) {
+            $nic = Get-WMIObject Win32_NetworkAdapterConfiguration | `
+                    where {$_.IPEnabled -eq "TRUE" -and $_.MACAddress -eq $mac}
+            Start-Sleep -s 1
+        }
 
         $nic.ReleaseDHCPLease()
         $nic.EnableStatic($ip , $netmask)

--- a/context.ps1
+++ b/context.ps1
@@ -107,6 +107,7 @@ function configureNetwork($context) {
         }
 
         # Run the configuration
+        $nic = $false
         while(!$nic) {
             $nic = Get-WMIObject Win32_NetworkAdapterConfiguration | `
                     where {$_.IPEnabled -eq "TRUE" -and $_.MACAddress -eq $mac}

--- a/context.ps1
+++ b/context.ps1
@@ -62,6 +62,7 @@ function addLocalUser($context) {
 
     # Add user to local Administrators
     $groups = "Administrators"
+    $groups = (Get-WmiObject -Class "Win32_Group" | where { $_.SID -like "S-1-5-32-544" } | select -ExpandProperty Name)
 
     foreach ($grp in $groups) {
     if([ADSI]::Exists("WinNT://$computerName/$grp,group")) {


### PR DESCRIPTION
Hi, this pull requset solve the problem: When the nic driver not yet installed, but the script already configures nic. Due this problem the IP configuration may be not configured.

Also includes @andremonteir fix for search for built-in Administrator account in system language.