### PR TITLE
Add additional context.ps1 improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.msi
 *.exe
+*.un~
+.idea

--- a/context.ps1
+++ b/context.ps1
@@ -122,25 +122,27 @@ function configureNetwork($context) {
         # Retrieve data from Context
         $nicPrefix = "ETH" + $nicId + "_"
 
-        $ipKey      = $nicPrefix + "IP"
-        $netmaskKey = $nicPrefix + "MASK"
-        $macKey     = $nicPrefix + "MAC"
-        $dnsKey     = $nicPrefix + "DNS"
-        $gatewayKey = $nicPrefix + "GATEWAY"
-        $networkKey = $nicPrefix + "NETWORK"
+        $ipKey        = $nicPrefix + "IP"
+        $netmaskKey   = $nicPrefix + "MASK"
+        $macKey       = $nicPrefix + "MAC"
+        $dnsKey       = $nicPrefix + "DNS"
+        $dnsSuffixKey = $nicPrefix + "SEARCH_DOMAIN"
+        $gatewayKey   = $nicPrefix + "GATEWAY"
+        $networkKey   = $nicPrefix + "NETWORK"
 
         $ip6Key      = $nicPrefix + "IP6"
         $gw6Key      = $nicPrefix + "GATEWAY6"
 
-        $ip      = $context[$ipKey]
-        $netmask = $context[$netmaskKey]
-        $mac     = $context[$macKey]
-        $dns     = $context[$dnsKey]
-        $gateway = $context[$gatewayKey]
-        $network = $context[$networkKey]
+        $ip        = $context[$ipKey]
+        $netmask   = $context[$netmaskKey]
+        $mac       = $context[$macKey]
+        $dns       = $context[$dnsKey]
+        $dnsSuffix = $context[$dnsSuffixKey]
+        $gateway   = $context[$gatewayKey]
+        $network   = $context[$networkKey]
 
-        $ip6     = $context[$ip6Key]
-        $gw6     = $context[$gw6Key]
+        $ip6       = $context[$ip6Key]
+        $gw6       = $context[$gw6Key]
 
         $mac = $mac.ToUpper()
         if (!$netmask) {

--- a/context.ps1
+++ b/context.ps1
@@ -299,9 +299,8 @@ function renameComputer($context) {
         }
         # Invalid JSON
         catch [System.ArgumentException] {
-            $status = @{}
-            $status["ErrorMsg"] = "Invalid JSON"
-            $status["FileContents"] = $json.ToString()
+            Write-Output "Invalid JSON:"
+            Write-Output $json.ToString()
         }
     }
 
@@ -320,26 +319,22 @@ function renameComputer($context) {
 
         $contents = @{}
         $contents["ComputerName"] = $context_hostname
+        ConvertTo-Json $contents | Out-File "$env:SystemDrive\.opennebula-renamed"
 
         # Check success
         If ($ret.ReturnValue) {
 
             # Returned Non Zero, Failed, No restart
             Write-Output ("  ... Failed: " + $ret.ReturnValue.ToString())
-            Write-Output "      Check the computername"
-
-            $contents["ErrorCode"] = $ret.ReturnValue.ToString()
-            $contents["ErrorMsg"] = 'Possible Issues: The name cannot include control characters, leading or trailing spaces, or any of the following characters: " / \\ [ ] : | < > + = ; , ?'
-            ConvertTo-Json $contents | Out-File "$env:SystemDrive\.opennebula-renamed"
+            Write-Output "      Check the computername."
+            Write-Output "Possible Issues: The name cannot include control" `
+                         "characters, leading or trailing spaces, or any of" `
+                         "the following characters: `" / \ [ ] : | < > + = ; , ?"
 
         } Else {
 
             # Returned Zero, Success
             Write-Output "... Success"
-
-            $contents["ErrorCode"] = $ret.ReturnValue.ToString()
-            $contents["ErrorMsg"] = "No Error"
-            ConvertTo-Json $contents | Out-File "$env:SystemDrive\.opennebula-renamed"
 
             # Restart the Computer
             Write-Output "... Rebooting"

--- a/context.ps1
+++ b/context.ps1
@@ -310,7 +310,10 @@ function renameComputer($context) {
                 "Set computername: $hostname" | Out-File "$env:SystemDrive\.opennebula-renamed"
 
                 # Restart the Computer
+                Write-Output "... Rebooting"
                 Restart-Computer -Force
+                Exit 0
+
             }
         }
     }


### PR DESCRIPTION
Reboots the computer if it is renamed
- Creates the `.opennebula-renamed` file when it attempts a rename to avoid getting stuck in a boot loop
- The `.opennebula-renamed` file contains JSON with information about the last rename attempt
- Future reboots evaluate `.opennebula-renamed` to compare `SET_HOSTNAME` from the context with the last attempted rename. If they differ, another rename is attempted. Otherwise it is skipped.
- If the `SET_HOSTNAME` from the value matches the `.opennebula-renamed` value, but the actual hostname is different, a message is displayed and logged.

Adds the ability to set the following DNS Settings:
- DNS Suffix Search Order
- Primary DNS Domain

Check if user is member of group before adding
- Avoids PowerShell error when the user already exists in the group

Cleans up and improves the logging.
- Uses `Write-Output` instead of `Write-Host` so that it shows up in the transcript
- Shows Success or Failure as much as possible