### PR TITLE
Fix check for nics

### DIFF
--- a/context.ps1
+++ b/context.ps1
@@ -122,12 +122,14 @@ function addLocalUser($context) {
 function configureNetwork($context) {
 
     # Get the NIC in the Context
-    $nicId = 0;
-    $nicIpKey = "ETH" + $nicId + "_IP"
-    $nicIp6Key = "ETH" + $nicId + "_IP6"
+    $nicIds = ($context.Keys | Where {$_ -match '^ETH\d+_IP6?$'} | ForEach-Object {$_ -replace '(^ETH|_IP$|_IP6$)',''} | Get-Unique)
 
-    while ($context[$nicIpKey] -Or $context[$nicIp6Key]) {
+    $nicId = 0;
+
+    foreach ($nicId in $nicIds) {
         # Retrieve data from Context
+        $nicIpKey = "ETH" + $nicId + "_IP"
+        $nicIp6Key = "ETH" + $nicId + "_IP6"
         $nicPrefix = "ETH" + $nicId + "_"
 
         $ipKey        = $nicPrefix + "IP"

--- a/context.ps1
+++ b/context.ps1
@@ -323,11 +323,6 @@ function configureNetwork($context) {
             }
             # TODO: maybe IPv6-based DNS servers should be added here?
         }
-
-        # Next NIC
-        $nicId++;
-        $nicIpKey = "ETH" + $nicId + "_IP"
-        $nicIp6Key = "ETH" + $nicId + "_IP6"
     }
     Write-Output ""
 }


### PR DESCRIPTION
Hello I added check for all nics before loop instead incrementing.

This is solves this problem: https://github.com/OpenNebula/addon-context-windows/pull/12#issuecomment-263737449
> This causes the script to hang if a second NIC is defined (ETH1) and there is only 1 NIC on the system.