### PR TITLE
Feature PASSWORD without USERNAME

### DIFF
--- a/context.ps1
+++ b/context.ps1
@@ -56,7 +56,15 @@ function addLocalUser($context) {
     $username =  $context["USERNAME"]
     $password =  $context["PASSWORD"]
 
-    if ($username) {
+    if ($username -Or $password) {
+
+        if ($username -eq $null) {
+            # ATTENTION - Language/Regional settings have influence on the naming
+            #             of this user. Use the User SID instead (S-1-5-21domain-500)
+            $username = (Get-WmiObject -Class "Win32_UserAccount" |
+                         where { $_.SID -like "S-1-5-21[0-9-]*-500" } |
+                         select -ExpandProperty Name)
+        }
 
         Write-Output "Creating Account for $username"
 


### PR DESCRIPTION
This code allow use PASSWORD without USERNAME like linux contextulisation.
If USERNAME is not set it will be calculated by Administrator SID: (S-1-5-21domain-500)
https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems