### PR TITLE
allow SET_HOSTNAME to be set to a FQDN

### DIFF
--- a/context.ps1
+++ b/context.ps1
@@ -450,7 +450,8 @@ function renameComputer($context) {
 
     # Initialize Variables
     $current_hostname = hostname
-    $context_hostname = $context["SET_HOSTNAME"]
+    $thostname = $context["SET_HOSTNAME"]
+    $context_hostname = $thostname.split(".",50)[0]
     $logged_hostname = "Unknown"
 
     if (! $context_hostname) {


### PR DESCRIPTION
If SET_HOSTNAME is set to a fqdn setting the hostname fails on Windows.
This is different to the current linux packages.
This patch splits the hostname and uses the hostname part only (first part before ".") to set the hostname.
