### PR TITLE
Update extendPartitions() diskpart regex

### DIFF
--- a/context.ps1
+++ b/context.ps1
@@ -667,7 +667,7 @@ function extendPartitions()
     $diskId = 0
 
     #$partIds = ((wmic partition where DiskIndex=$diskId get Index | Select-String "[0-9]+") -replace '\D','' | %{[int]$_ + 1})
-    $partIds = "select disk $diskId", "list partition" | diskpart | Select-String -Pattern "^  Partition \d" -AllMatches | %{$_.matches} | %{$_.value.replace("  Partition ", "") }
+    $partIds = "select disk $diskId", "list partition" | diskpart | Select-String -Pattern "^\s+\w+ (\d+)\s+" -AllMatches | %{$_.matches.groups[1].Value}
 
     ForEach ($partId in $partIds) {
         extendPartition $diskId $partId


### PR DESCRIPTION
As of now `$partIds = ...` part works with English interface only. New regex support any locale.