### PR TITLE
F #75: disable Windows FastBoot feature

### DIFF
--- a/package.wxs
+++ b/package.wxs
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?define UpgradeCode = "2056bd8a-bf03-11e6-a625-f0def1753696" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
   <Product Name="OpenNebula Contextualization"
     Manufacturer="OpenNebula Systems"
     Id="*"
@@ -37,6 +38,38 @@
         Name="Path" />
     </Property>
     <Condition Message="Windows PowerShell not found.">INSTALLED OR PSEXE</Condition>
+
+    <!-- Register property FASTBOOT -->
+    <Property Id="FASTBOOT">
+      <RegistrySearch Id="FASTBOOT"
+        Type="raw"
+        Root="HKLM"
+        Key="SYSTEM\CurrentControlSet\Control\Session Manager\Power"
+        Name="HiberbootEnabled" />
+    </Property>
+
+    <!--
+      workaround for missing features in wixl implementation...there should be
+      a couple of ways how to achieve the same with WiX semantics but the wixl
+      support is limited and running an exe was the only properly working
+      solution for the time being:
+        1. overwrite already existing registry
+        2. do not delete the registry on uninstall...
+    -->
+    <Property Id="REG" Value="C:\Windows\System32\reg.exe" />
+
+    <!-- Register action DisableFastBoot -->
+    <!--
+      wixl from msitools does not support all WiX features - like these:
+        <SetProperty Id="FASTBOOT" Value="#0" Before="InstallValidate" />
+        <CustomAction Id="DisableFastBoot" Property="FASTBOOT" Value="#0" />
+    -->
+    <CustomAction Id="DisableFastBoot"
+      Property="REG"
+      ExeCommand='add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Power" /v HiberbootEnabled /t REG_DWORD /d 0 /f'
+      Execute="deferred"
+      Impersonate="no"
+      />
 
     <!-- Install files -->
     <Directory Id="TARGETDIR" Name="SourceDir">
@@ -91,7 +124,25 @@
     </Feature>
 
     <InstallExecuteSequence>
-      <RemoveExistingProducts After="InstallValidate"/>
+      <!-- NOTE:
+          This works for msitools/wixl implementation (v0.98) but according to
+          WiX documentation:
+          https://wixtoolset.org/documentation/manual/v3/xsd/wix/custom.html
+
+          it should not - 'Before' and 'After' are mutually exclusive...
+          *BUT* if we do not specify both of them like this the custom action
+          'DisableFastBoot' will not get the right sequence number - another
+          fix could be to use only 'Sequence' and somehow figure out the
+          correct number for it - at the time of the writing it should be
+          somewhere between 'InstallInitialize' (1500) and 'InstallFinalize'
+          (6600).
+
+          The reason why we need to be between these two stages is the fact
+          that we must run 'DisableFastBoot' as 'deffered' to get elevated
+          privileges...
+      -->
+      <Custom Action="DisableFastBoot" After="InstallInitialize" Before="InstallFinalize">NOT REMOVE AND FASTBOOT</Custom>
+      <RemoveExistingProducts After="InstallValidate" />
     </InstallExecuteSequence>
   </Product>
 </Wix>


### PR DESCRIPTION
- set system registry value 'HiberbootEnabled' to zero to disable
  FastBoot feature of the Windows

NOTE:
    wixl from msitools (https://wiki.gnome.org/msitools) does not
    implement all features of the WiX - I had to find a way how to
    achieve the zeroing of the foreign registry key and avoid the
    deletion of this registry on the uninstall...

    It does not mean that the current way is the best approach
    available.

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>

<!--//////////////////////////////////////////////////////////-->
<!-- Please note the pull request can be merged only if all   -->
<!-- commits are properly signed! Read the instructions here: -->
<!-- https://github.com/OpenNebula/one/wiki/Sign-Your-Work    -->
<!--//////////////////////////////////////////////////////////-->

Changes proposed in this pull request:
- disable Windows FastBoot feature
