### PR TITLE
Fix #97 where EJECT_CDROM won't work on Core edition.

### DIFF
--- a/src/context.ps1
+++ b/src/context.ps1
@@ -1207,14 +1207,12 @@ function ejectContextCD($cdrom_drive)
     if ($eject_cdrom -ne $null -and $eject_cdrom.ToUpper() -eq 'YES') {
         logmsg '* Ejecting context CD'
         try {
-            $disk_master = New-Object -ComObject IMAPI2.MsftDiscMaster2
-            for ($cdrom_id = 0; $cdrom_id -lt $disk_master.Count; $cdrom_id++) {
-                $disk_recorder = New-Object -ComObject IMAPI2.MsftDiscRecorder2
-                $disk_recorder.InitializeDiscRecorder($disk_master.Item($cdrom_id))
-                if ($disk_recorder.VolumeName -eq $cdrom_drive.DeviceID) {
-                    $disk_recorder.EjectMedia()
-                    break
-                }
+            #https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+            $ssfDRIVES = 0x11
+            $sh = New-Object -ComObject "Shell.Application"
+            $sh.Namespace($ssfDRIVES).Items() | Where-Object { $_.Type -eq "CD Drive" -and $_.Path -eq $cdrom_drive.Name } | ForEach-Object {
+                $_.InvokeVerb("Eject")
+                logmsg " ... Ejected $($cdrom_drive.Name)"
             }
         } catch {
             logmsg "  ... Failed to eject the CD: $_"


### PR DESCRIPTION
Changes proposed in this pull request:
- Improved EJECT_CDROM to work with Windows Server Core 2016/2019/2022

There was the following error as it fails to create `New-Object -ComObject IMAPI2.MsftDiscMaster2`:
```
[2022-10-27 03:09 -07:00] * Ejecting context CD
[2022-10-27 03:09 -07:00]   ... Failed to eject the CD: Retrieving the COM class factory for component with CLSID
{00000000-0000-0000-0000-000000000000} failed due to the following error: 80040154 Class not registered (Exception
from HRESULT: 0x80040154 (REGDB_E_CLASSNOTREG)).
```

After changes this is shown in logs:
```
[2022-10-27 16:44 +03:00] * Ejecting context CD
[2022-10-27 16:44 +03:00]  ... Ejected D:\
``` 